### PR TITLE
Hide incorrect pageview count. Updated the props, preserving the comp.

### DIFF
--- a/src/app/components/App.jsx
+++ b/src/app/components/App.jsx
@@ -352,7 +352,7 @@ class App extends React.Component {
             </div>
             <Dialogs />
             <Modals />
-            <PageViewsCounter />
+            <PageViewsCounter hidden={true} />
         </div>
     }
 }

--- a/src/app/components/cards/PostFull.jsx
+++ b/src/app/components/cards/PostFull.jsx
@@ -402,7 +402,7 @@ class PostFull extends React.Component {
                   </Link>
                 </span>
                 <span className="PostFull__views">
-                  <PageViewsCounter hidden={false} sinceDate={isPreViewCount ? 'Dec 2016' : null} />
+                  <PageViewsCounter hidden={true} sinceDate={isPreViewCount ? 'Dec 2016' : null} />
                 </span>
                 <ShareMenu menu={share_menu} />
                 <button className="explore-post" title={tt('g.share_this_post')} onClick={this.showExplorePost}>

--- a/src/app/components/elements/PageViewsCounter.jsx
+++ b/src/app/components/elements/PageViewsCounter.jsx
@@ -41,6 +41,7 @@ export default class PageViewsCounter extends React.Component {
     render() {
         const views = this.state.views;
         if (this.props.hidden || !views) return null;
+
         const suffix = this.props.sinceDate ? tt('g.since') + this.props.sinceDate : '';
         return <span className="PageViewsCounter" title={tt('g.views', {count: views}) + suffix}>
             <Icon name="eye" /> {views.toLocaleString()}


### PR DESCRIPTION
This PR is related to the latest issue raised about the incorrect page view counts. 

Updated the props, preserving the component for posterity.

